### PR TITLE
Utilities for reading mtgo client decklist output

### DIFF
--- a/MTG/read_utils.R
+++ b/MTG/read_utils.R
@@ -1,0 +1,44 @@
+
+## Helper function for parse_decklist
+read.mtg <- function(file_path) {
+  ## Read in mtg decklists saved in mtgo format specified here:
+  ## https://magic.wizards.com/en/articles/archive/magic-online-reads-text-files-2004-10-26
+  ## This format of each line is expected to be:
+  ##  "x card name"
+  ##  where "x" is the number of "card name" in the deck.
+  
+  ## Read mtg file by line
+  x <- readLines(file_path)
+  
+  ## Remove blank lines
+  x <- x[which(x != "")]
+  
+  ## Extract card counts from first set of characters 
+  ## appearing before the first space of each line
+  counts <- as.numeric(sub(" .*", "", x))
+  
+  ## Extract card names appearing after the first space of each line.
+  ##  The first space will still remain in the substring.
+  card_names <- sub(" *.", "", x)
+  
+  ## Remove the remaining first space from the card names
+  card_names <- sapply(card_names, substring, first = 2, USE.NAMES = FALSE)
+  
+  data.frame(name = card_names,
+             quantity = counts)
+}
+
+## Convert Magic: the Gathering Online output decklist
+## into format expected by optimization functions.
+parse_decklist <- function(file_path) {
+  ## Actual drafted decklist.
+  ## Output from Magic: the Gathering Online client
+  my_deck <- read.mtg(file_path)
+  
+  ## Premade Guilds of Ravnica cardlist data set
+  grn_cardlist <- read.csv("GRN.csv", stringsAsFactors = FALSE)
+  
+  merge(x = grn_cardlist[,-ncol(grn_cardlist)], ## Drop the last column "quantity"
+        y = my_deck, ## Provides the actual card quantity
+        by = "name")
+}

--- a/R/MTGopt.R
+++ b/R/MTGopt.R
@@ -3,7 +3,7 @@
 source("MTG/MTGopt_funcs.R")
 source("MTG/read_utils.R")
 
-draft <- parse_decklist("sample_grn_decklist.txt")
+draft <- parse_decklist("sample_grn_decklist.txt" )
 
 num.colors <- 4
 num.non.land <- 23

--- a/R/MTGopt.R
+++ b/R/MTGopt.R
@@ -1,7 +1,9 @@
 # MTGopt.R
 
 source("MTG/MTGopt_funcs.R")
-draft <- read.csv("GRN_180929.csv", stringsAsFactors = FALSE)
+source("MTG/read_utils.R")
+
+draft <- parse_decklist("sample_grn_decklist.txt")
 
 num.colors <- 4
 num.non.land <- 23

--- a/sample_grn_decklist.txt
+++ b/sample_grn_decklist.txt
@@ -1,0 +1,41 @@
+1 Chamber Sentry
+1 District Guide
+1 Emmara, Soul of the Accord
+2 Generous Stray
+3 Healer's Hawk
+1 Kraul Harpooner
+1 Loxodon Restorer
+1 Midnight Reaper
+2 Parhelion Patrol
+2 Siege Wurm
+1 Sunhome Stalwart
+1 Gird for Battle
+1 Prey Upon
+1 Assassin's Trophy
+1 Take Heart
+1 Conclave Tribunal
+2 Luminous Bonds
+4 Forest
+1 Golgari Guildgate
+1 Overgrown Tomb
+7 Plains
+3 Selesnya Guildgate
+1 Swamp
+
+
+1 Boros Guildgate
+1 Circuitous Route
+1 Collar the Culprit
+1 Crushing Canopy
+1 Drowned Secrets
+1 Garrison Sergeant
+2 Hitchclaw Recluse
+1 Maximize Altitude
+1 Pause for Reflection
+1 Pitiless Gorgon
+1 Righteous Blow
+1 Torch Courier
+1 Truefire Captain
+1 Urban Utopia
+1 Vicious Rumors
+1 Worldsoul Colossus


### PR DESCRIPTION
Added a sample sealed MTGO decklist from: https://bit.ly/2NYp87d

Created /MTG/read_utils.R with two functions:
read.mtg() reads in the raw decklist
parse_decklist() attached the card counts from an MTGO decklist to GRN.csv

Inserted parse_decklist() into MTGopt.R to demonstrate its use on sample MTGO decklist.